### PR TITLE
Make tslint-etc a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "eslint-etc": "^0.0.8",
     "requireindex": "~1.2.0",
     "tslib": "^1.8.0",
-    "tslint-etc": "^1.6.0",
     "tsutils": "^3.0.0",
     "tsutils-etc": "^1.0.0"
   },
@@ -30,6 +29,7 @@
     "rimraf": "^3.0.0",
     "ts-node": "^8.0.2",
     "tslint": "^6.0.0",
+    "tslint-etc": "^1.6.0",
     "typescript": "~3.8.3"
   },
   "homepage": "https://github.com/cartant/eslint-plugin-etc",


### PR DESCRIPTION
This prevents peerDependency warnings about missing tslint dependencies.
It seems to not be used