### PR TITLE
feat: add support for custom message in ban-import

### DIFF
--- a/tests/rules/ban-imports.ts
+++ b/tests/rules/ban-imports.ts
@@ -13,6 +13,8 @@ const options = [
     "^a$": true,
     "^b$": false,
     "(^|/)c$": true,
+    "^m$": "'m' has been deprecated; use 'baz'",
+    "^n$": "",
   },
 ];
 
@@ -24,6 +26,10 @@ ruleTester({ types: false }).run("ban-imports", rule, {
     },
     {
       code: `import { d } from "./d";`,
+      options,
+    },
+    {
+      code: `import { n } from "n";`,
       options,
     },
   ],
@@ -42,5 +48,24 @@ ruleTester({ types: false }).run("ban-imports", rule, {
       `,
       { options }
     ),
+    fromFixture(
+      stripIndent`
+        import { m } from "m";
+        ~~~~~~~~~~~~~~~~~~~~~~ [forbidden]
+      `,
+      { options }
+    ),
+    {
+      code: stripIndent`
+        import { m } from "m";
+      `,
+      options,
+      errors: [
+        {
+          messageId: "forbidden",
+          data: { message: "'m' has been deprecated; use 'baz'" },
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
**Some notes:**
- dunno if bug or missing definition within typescript-eslint experimental tools bud this should be easier to implement as `context.report` [supports `message` directly](https://eslint.org/docs/developer-guide/working-with-rules#contextreport-1) (not present in ts-eslint exp tools), that's why I used that template interpolation workaround

