### PR TITLE
Add docs about `useUnknownInCatchVariables`

### DIFF
--- a/docs/rules/no-implicit-any-catch.md
+++ b/docs/rules/no-implicit-any-catch.md
@@ -1,6 +1,6 @@
 # Use type-safe error callbacks (`no-implicit-any-catch`)
 
-This rule requires an explicit type annotation for error parameters in promise `catch` callbacks. It's similar to the TypeScript [`no-implicit-any-catch`](https://github.com/typescript-eslint/typescript-eslint/blob/e01204931e460f5e6731abc443c88d666ca0b07a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md) rule, but is for promises - not `try`/`catch` statements.
+This rule requires an explicit type annotation for error parameters in promise `catch` callbacks. It's similar to TypeScript 4.4's [`useUnknownInCatchVariables`](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables) but is for promises - not `try`/`catch` statements.
 
 ## Rule details
 
@@ -35,7 +35,9 @@ This rule accepts a single option which is an object with an `allowExplicitAny` 
 
 ## Related
 
-- [`no-implicit-any-catch`](https://github.com/typescript-eslint/typescript-eslint/blob/e01204931e460f5e6731abc443c88d666ca0b07a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md)
+- [`useUnknownInCatchVariables`](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables) for catching a similar issue in `try`/`catch` statements
+- [`no-implicit-any-catch`](https://github.com/typescript-eslint/typescript-eslint/blob/e01204931e460f5e6731abc443c88d666ca0b07a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md) - a now-deprecated lint rule that did the same thing for `try`/`catch` statements before `useUnknownInCatchVariables` was added
+
 
 ## Further reading
 


### PR DESCRIPTION
the related `no-implicit-any-catch` rule is now deprecated because TS 4.4 added support for that check natively (for `try/catch` statements): https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md

Adding docs about the new way to do this here.

![image](https://user-images.githubusercontent.com/3213339/199837766-531fff59-73a5-4c94-b17c-d4ca40f5805f.png)
