### PR TITLE
Add support for TypeScript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "url": "https://github.com/cartant/eslint-plugin-etc/issues"
   },
   "dependencies": {
-    "@phenomnomnominal/tsquery": "^5.0.0",
+    "@phenomnomnominal/tsquery": "^5.0.1",
     "@typescript-eslint/experimental-utils": "^5.0.0",
-    "eslint-etc": "^5.1.0",
+    "eslint-etc": "^5.2.1",
     "requireindex": "~1.2.0",
     "tslib": "^2.0.0",
     "tsutils": "^3.0.0"
@@ -49,7 +49,7 @@
   "optionalDependencies": {},
   "peerDependencies": {
     "eslint": "^8.0.0",
-    "typescript": "^4.0.0"
+    "typescript": ">=4.0.0"
   },
   "private": false,
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@phenomnomnominal/tsquery@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-5.0.0.tgz#5e99f4a073740e10ee6945cebb477ccf9de74482"
-  integrity sha512-1k9H74MJJrlZbUuM6rG0Kwifu/ZoshH+Qs1QXJ2P2RD6MRE/D49uSzXosOXIpIrRQNtij3bnkukexIZhgM/Q8g==
+"@phenomnomnominal/tsquery@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz#a2a5abc89f92c01562a32806655817516653a388"
+  integrity sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==
   dependencies:
     esquery "^1.4.0"
 
@@ -671,10 +671,10 @@ escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-etc@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-etc/-/eslint-etc-5.2.0.tgz#c51c19a2ffb6447af76a1c5ffd13b9a212db859b"
-  integrity sha512-Gcm/NMa349FOXb1PEEfNMMyIANuorIc2/mI5Vfu1zENNsz+FBVhF62uY6gPUCigm/xDOc8JOnl+71WGnlzlDag==
+eslint-etc@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-etc/-/eslint-etc-5.2.1.tgz#43e2554a347677ebb6386c915f374918f2efcb87"
+  integrity sha512-lFJBSiIURdqQKq9xJhvSJFyPA+VeTh5xvk24e8pxVL7bwLBtGF60C/KRkLTMrvCZ6DA3kbPuYhLWY0TZMlqTsg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.0.0"
     tsutils "^3.17.1"


### PR DESCRIPTION
Closes #53

This PR should fix peer dependencies warnings for TypeScript 5, based on the output of Yarn Berry:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/990773/233771009-8aa953ec-744e-4c23-85cd-644b7399032a.png">

It would be great if you could make a npm release after merging this PR 😉