### PR TITLE
`no-assign-mutated-array`  Allow mutation of an array after flat and flatMap

### DIFF
--- a/source/rules/no-assign-mutated-array.ts
+++ b/source/rules/no-assign-mutated-array.ts
@@ -17,7 +17,8 @@ import {
 import { ruleCreator } from "../utils";
 
 const mutatorRegExp = /^(fill|reverse|sort)$/;
-const creatorRegExp = /^(concat|entries|filter|keys|map|slice|splice|values)$/;
+const creatorRegExp =
+  /^(concat|entries|filter|keys|map|slice|splice|values|flat|flatMap)$/;
 
 const rule = ruleCreator({
   defaultOptions: [],

--- a/tests/rules/no-assign-mutated-array.ts
+++ b/tests/rules/no-assign-mutated-array.ts
@@ -146,6 +146,24 @@ ruleTester({ types: true }).run("no-assign-mutated-array", rule, {
     },
     {
       code: stripIndent`
+      // flat & mutated variable assignment
+      const a = [[0, 1], [2, 3]];
+      const b = a.flat().fill(0);
+      const c = a.flat().reverse();
+      const d = a.flat().sort();
+      `,
+    },
+    {
+      code: stripIndent`
+      // flatMap & mutated variable assignment
+      const a = [[0, 1], [2, 3]];
+      const b = a.flatMap(e => e).fill(0);
+      const c = a.flatMap(e => e).reverse();
+      const d = a.flatMap(e => e).sort();
+      `,
+    },
+    {
+      code: stripIndent`
         // https://github.com/cartant/eslint-plugin-etc/issues/27
         const a = new Array(10).fill(0);
         const b = Array(10).fill(0);


### PR DESCRIPTION
## Changes

- Update creatorRegExp in `no-assign-mutated-array` rule to include flat and flatMap
- Updates tests to check that mutation after flat and flatMap is valid

## Notes
[flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) and [flatMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) both return new arrays so it is safe to assign them after mutation.